### PR TITLE
Fix a typo in the frontmatter example

### DIFF
--- a/pages/basics/frontmatter.html.md
+++ b/pages/basics/frontmatter.html.md
@@ -7,7 +7,7 @@ order: 4
 Frontmatter is a way to add metadata to your pages and access it from templates and the sitemap. Consider the following page:
 
 ```md
-----
+---
 title: Apollo 40th anniversery
 layout: video
 video_url: https://www.youtube.com/watch?v=ez0bFWKR9-0


### PR DESCRIPTION
## What 

This fixes a typo in the front-matter example where it displayed four dashes as the start of the front-matter instead of three dashes. 

## Why 

Starting with four dashes will invalidate the front-matter syntax; thus, anyone who would have copied that example would have found that it does not work.

## How

I removed one dash and ensured it followed the front matter example.
