### PR TITLE
Fix typo in resource data dot method.

### DIFF
--- a/pages/basics/frontmatter.html.md
+++ b/pages/basics/frontmatter.html.md
@@ -38,7 +38,7 @@ The data can also be accessed by calling dot methods for the keys.
     %title=resource.data.title!
   %body
     %h1=resource.data.title
-    %iframe{src: resource.data.vido_url}
+    %iframe{src: resource.data.video_url}
     %p=yield
 ```
 


### PR DESCRIPTION
This fixes a small typo in the `video_url` example in the dot method.